### PR TITLE
feat: add ASP.NET Core Web API project

### DIFF
--- a/InventoryKpiSystem.sln
+++ b/InventoryKpiSystem.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
@@ -11,6 +12,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Inventory.ConsoleApp", "src\Inventory.ConsoleApp\Inventory.ConsoleApp.csproj", "{D99B3FB9-1C3F-4ACB-91AC-C9410920E8B0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Inventory.Application.Tests", "tests\Inventory.Application.Tests\Inventory.Application.Tests.csproj", "{D568C99A-FD7E-44F4-A58A-FE024D4B8C34}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Inventory.Api", "src\Inventory.Api\Inventory.Api.csproj", "{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -82,9 +87,24 @@ Global
 		{D568C99A-FD7E-44F4-A58A-FE024D4B8C34}.Release|x64.Build.0 = Release|Any CPU
 		{D568C99A-FD7E-44F4-A58A-FE024D4B8C34}.Release|x86.ActiveCfg = Release|Any CPU
 		{D568C99A-FD7E-44F4-A58A-FE024D4B8C34}.Release|x86.Build.0 = Release|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Debug|x64.Build.0 = Debug|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Debug|x86.Build.0 = Debug|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Release|x64.ActiveCfg = Release|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Release|x64.Build.0 = Release|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Release|x86.ActiveCfg = Release|Any CPU
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{537BEAC9-DAAC-4A92-87EF-56F95D1E2C02} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1C25E4C-AEEF-446F-B4B6-2C9945BC952A}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Inventory KPI Monitoring System
 
-Inventory KPI Monitoring System is a .NET 10 console application for importing product and invoice files, maintaining inventory state, and producing inventory KPI reports.
+Inventory KPI Monitoring System is a .NET 10 application for importing product and invoice files, maintaining inventory state, and producing inventory KPI reports.
 
-The current codebase uses a Clean Architecture layout. Domain rules and application services are separated from file parsing, JSON persistence, reporting, and console presentation.
+The current codebase uses a Clean Architecture layout. Domain rules and application services are separated from file parsing, JSON persistence, reporting, console presentation, and the HTTP API layer.
 
 ## Project Structure
 
@@ -12,6 +12,7 @@ src/
   Inventory.Application/     Interfaces, DTOs, import logic, FIFO costing, and KPI services
   Inventory.Infrastructure/  File readers, JSON snapshot storage, processed-file registry, reporting
   Inventory.ConsoleApp/      Console startup, file monitoring, and interactive report menu
+  Inventory.Api/             ASP.NET Core Web API endpoints and OpenAPI documentation
 
 tests/
   Inventory.Application.Tests/  Unit tests for application services
@@ -35,6 +36,9 @@ InventoryKpiSystem/
 - Persists inventory state to `InventoryKpiSystem/inventory-snapshot.json`.
 - Tracks processed files in `InventoryKpiSystem/processed-files/processed-files.json`.
 - Writes JSON reports to `InventoryKpiSystem/reports`.
+- Exposes inventory, product, KPI, and import workflows through ASP.NET Core endpoints.
+
+Persistence is still file-based in this task. No database, EF Core, authentication, or frontend is included.
 
 ## KPI Calculations
 
@@ -48,9 +52,27 @@ The application currently calculates:
 
 ## File Import
 
-Product and invoice data are file-based JSON inputs. The console app loads historical files at startup, then monitors the product and invoice folders for additional files.
+Product and invoice data are file-based JSON inputs. The console app loads historical files at startup, then monitors the product and invoice folders for additional files. The API can run the same import workflow through `POST /api/import/run`.
 
 The console project links the sample data from `InventoryKpiSystem/Data` into the build output, while still resolving the root sample data folder when run from the repository root.
+
+## API
+
+`Inventory.Api` is an ASP.NET Core Web API project that exposes the existing application services over HTTP without changing the FIFO or KPI business logic.
+
+Endpoints:
+
+- `GET /health`
+- `GET /api/products`
+- `GET /api/inventory`
+- `GET /api/kpis`
+- `POST /api/import/run`
+
+OpenAPI documentation is available at:
+
+```text
+/openapi/v1.json
+```
 
 ## Reports
 
@@ -76,13 +98,21 @@ dotnet build InventoryKpiSystem.sln
 dotnet test InventoryKpiSystem.sln
 ```
 
-## Run
+## Run Console App
 
 ```bash
 dotnet run --project src/Inventory.ConsoleApp/Inventory.ConsoleApp.csproj
 ```
 
 When running, the app syncs historical product and invoice data, saves the inventory snapshot, starts folder monitoring, and opens the console report menu.
+
+## Run API
+
+```bash
+dotnet run --project src/Inventory.Api/Inventory.Api.csproj
+```
+
+The API reads and writes the same file-based sample/runtime data under `InventoryKpiSystem/`.
 
 ## Current Validation
 

--- a/src/Inventory.Api/Inventory.Api.csproj
+++ b/src/Inventory.Api/Inventory.Api.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Inventory.Application\Inventory.Application.csproj" />
+    <ProjectReference Include="..\Inventory.Infrastructure\Inventory.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Inventory.Api/Inventory.Api.http
+++ b/src/Inventory.Api/Inventory.Api.http
@@ -1,0 +1,26 @@
+@Inventory.Api_HostAddress = http://localhost:5258
+
+GET {{Inventory.Api_HostAddress}}/health
+Accept: application/json
+
+###
+
+GET {{Inventory.Api_HostAddress}}/api/products
+Accept: application/json
+
+###
+
+GET {{Inventory.Api_HostAddress}}/api/inventory
+Accept: application/json
+
+###
+
+GET {{Inventory.Api_HostAddress}}/api/kpis
+Accept: application/json
+
+###
+
+POST {{Inventory.Api_HostAddress}}/api/import/run
+Accept: application/json
+
+###

--- a/src/Inventory.Api/Program.cs
+++ b/src/Inventory.Api/Program.cs
@@ -1,0 +1,164 @@
+using Inventory.Application.Interfaces;
+using Inventory.Application.Services;
+using Inventory.Infrastructure.FileParsing;
+using Inventory.Infrastructure.Json;
+using Inventory.Infrastructure.Reporting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var dataPaths = ResolveDataPaths(builder.Environment.ContentRootPath);
+
+builder.Services.AddOpenApi();
+builder.Services.AddSingleton(dataPaths);
+builder.Services.AddSingleton<IFifoCostingService, FifoCostingService>();
+builder.Services.AddSingleton<IInventorySnapshotStore>(_ =>
+    new JsonInventorySnapshotStore(Path.Combine(dataPaths.RuntimeRoot, "inventory-snapshot.json")));
+builder.Services.AddSingleton<IInventoryService>(provider =>
+{
+    var fifoCostingService = provider.GetRequiredService<IFifoCostingService>();
+    var snapshotStore = provider.GetRequiredService<IInventorySnapshotStore>();
+    return new InventoryService(fifoCostingService, snapshotStore.Load());
+});
+builder.Services.AddSingleton<IImportService, ImportService>();
+builder.Services.AddSingleton<IKpiService, KpiService>();
+builder.Services.AddSingleton<IProductFileReader, ProductFileReader>();
+builder.Services.AddSingleton<IInvoiceFileReader, InvoiceFileReader>();
+builder.Services.AddSingleton<IProcessedFileRegistry>(_ =>
+    new ProcessedFileRegistry(Path.Combine(dataPaths.RuntimeRoot, "processed-files")));
+builder.Services.AddSingleton<IReportWriter>(_ =>
+    new JsonReportWriter(Path.Combine(dataPaths.RuntimeRoot, "reports")));
+builder.Services.AddSingleton<FileProcessor>();
+
+var app = builder.Build();
+
+app.MapOpenApi();
+
+app.MapGet("/health", () => Results.Ok(new
+{
+    status = "Healthy",
+    checkedAt = DateTime.UtcNow
+}))
+.WithName("Health");
+
+app.MapGet("/api/products", (IInventoryService inventoryService) =>
+{
+    var products = inventoryService.GetAllInventory()
+        .OrderBy(item => item.ItemCode)
+        .Select(item => new
+        {
+            item.ProductId,
+            item.ItemCode,
+            item.Name
+        });
+
+    return Results.Ok(products);
+})
+.WithName("GetProducts");
+
+app.MapGet("/api/inventory", (IInventoryService inventoryService) =>
+{
+    var inventory = inventoryService.GetAllInventory()
+        .OrderBy(item => item.ItemCode)
+        .Select(item => new
+        {
+            item.ProductId,
+            item.ItemCode,
+            item.Name,
+            item.QuantityOnHand,
+            item.TotalSoldQuantity,
+            item.TotalStockValue,
+            PurchaseBatches = item.PurchaseBatches
+                .OrderBy(batch => batch.PurchaseDate)
+                .Select(batch => new
+                {
+                    batch.PurchaseDate,
+                    batch.UnitCost,
+                    batch.InitialQuantity,
+                    batch.RemainingQuantity
+                })
+        });
+
+    return Results.Ok(inventory);
+})
+.WithName("GetInventory");
+
+app.MapGet("/api/kpis", (IInventoryService inventoryService, IKpiService kpiService) =>
+{
+    var snapshot = kpiService.CreateSnapshot(inventoryService.GetAllInventory());
+    return Results.Ok(snapshot);
+})
+.WithName("GetKpis");
+
+app.MapPost("/api/import/run", async (
+    ApiDataPaths paths,
+    FileProcessor processor,
+    IInventoryService inventoryService,
+    IInventorySnapshotStore snapshotStore,
+    CancellationToken cancellationToken) =>
+{
+    if (!Directory.Exists(paths.ProductsFolder) || !Directory.Exists(paths.InvoicesFolder))
+    {
+        return Results.NotFound(new
+        {
+            message = "Product or invoice data folder was not found.",
+            paths.ProductsFolder,
+            paths.InvoicesFolder
+        });
+    }
+
+    var productFiles = Directory.GetFiles(paths.ProductsFolder, "*.txt")
+        .OrderBy(file => file)
+        .ToList();
+
+    var invoiceFiles = Directory.GetFiles(paths.InvoicesFolder, "*.txt")
+        .OrderBy(file => file)
+        .ToList();
+
+    foreach (var file in productFiles)
+    {
+        await processor.ProcessProductFileAsync(file, cancellationToken);
+    }
+
+    foreach (var file in invoiceFiles)
+    {
+        await processor.ProcessInvoiceFileAsync(file, cancellationToken);
+    }
+
+    snapshotStore.Save(inventoryService.Items);
+
+    return Results.Ok(new
+    {
+        message = "Import completed.",
+        productFilesProcessed = productFiles.Count,
+        invoiceFilesProcessed = invoiceFiles.Count,
+        inventoryItems = inventoryService.Items.Count
+    });
+})
+.WithName("RunImport");
+
+app.Run();
+
+static ApiDataPaths ResolveDataPaths(string contentRoot)
+{
+    var currentDirectory = Directory.GetCurrentDirectory();
+    var candidates = new[]
+    {
+        Path.GetFullPath(Path.Combine(currentDirectory, "InventoryKpiSystem")),
+        Path.GetFullPath(Path.Combine(contentRoot, "..", "..", "InventoryKpiSystem")),
+        Path.GetFullPath(Path.Combine(contentRoot, "InventoryKpiSystem"))
+    };
+
+    var runtimeRoot = candidates.FirstOrDefault(path =>
+        Directory.Exists(Path.Combine(path, "Data", "Products")) &&
+        Directory.Exists(Path.Combine(path, "Data", "Invoices"))) ?? candidates[0];
+
+    return new ApiDataPaths(
+        Path.Combine(runtimeRoot, "Data", "Products"),
+        Path.Combine(runtimeRoot, "Data", "Invoices"),
+        runtimeRoot);
+}
+
+internal sealed record ApiDataPaths(
+    string ProductsFolder,
+    string InvoicesFolder,
+    string RuntimeRoot);

--- a/src/Inventory.Api/Properties/launchSettings.json
+++ b/src/Inventory.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5258",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Inventory.Api/appsettings.Development.json
+++ b/src/Inventory.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Inventory.Api/appsettings.json
+++ b/src/Inventory.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- Added ASP.NET Core Web API project
- Exposed existing inventory, product, KPI, and import workflows through HTTP endpoints
- Added Swagger/OpenAPI support
- Kept persistence file-based for this task
- Preserved existing FIFO and KPI business logic

## Endpoints
- GET /health
- GET /api/products
- GET /api/inventory
- GET /api/kpis
- POST /api/import/run

## Validation
- dotnet build InventoryKpiSystem.sln
- dotnet test InventoryKpiSystem.sln
- Existing tests passed

## Notes
- No database, EF Core, authentication, frontend, or LLM features were added
- This PR only introduces the API layer on top of the existing clean architecture