### PR TITLE
feat: persist inventory imports to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ InventoryKpiSystem/
 - Applies FIFO inventory logic by consuming the oldest purchase lots first.
 - Calculates inventory KPIs from the current inventory state.
 - Persists inventory state to `InventoryKpiSystem/inventory-snapshot.json`.
+- Persists imported products, invoices, inventory items, stock lots, and stock movements to PostgreSQL through the API import endpoint.
 - Tracks processed files in `InventoryKpiSystem/processed-files/processed-files.json`.
 - Writes JSON reports to `InventoryKpiSystem/reports`.
 - Exposes inventory, product, KPI, and import workflows through ASP.NET Core endpoints.
-- Includes a PostgreSQL EF Core foundation for future database persistence work.
+- Includes PostgreSQL EF Core repositories for persisted inventory state.
 
-File-based import behavior remains in place. The PostgreSQL schema foundation is available, but FIFO and KPI workflows have not been rewritten to use database persistence yet.
+File-based import behavior remains the source of input data. PostgreSQL is used for persisted inventory state after `POST /api/import/run`. FIFO and KPI business logic are unchanged.
 
 ## KPI Calculations
 
@@ -79,14 +80,15 @@ Swagger UI and OpenAPI documentation are available at:
 /openapi/v1.json
 ```
 
-Database-backed runtime workflows are planned as future work. The current API still uses the file-based sample/runtime data under `InventoryKpiSystem/` for import, inventory state, and reports.
+The current API still reads source import files from `InventoryKpiSystem/`. After import, `GET /api/products`, `GET /api/inventory`, and `GET /api/kpis` read from PostgreSQL when database data is available.
 
 ## PostgreSQL
 
-`Inventory.Infrastructure` contains the EF Core foundation:
+`Inventory.Infrastructure` contains the EF Core persistence layer:
 
 - `InventoryDbContext`
 - Entity mappings under `src/Inventory.Infrastructure/Persistence/Configurations`
+- Repository implementations under `src/Inventory.Infrastructure/Persistence/Repositories`
 - Initial migration under `src/Inventory.Infrastructure/Persistence/Migrations`
 
 The API registers `InventoryDbContext` with the `InventoryDb` connection string.
@@ -118,6 +120,22 @@ Database health check:
 ```text
 GET /health/db
 ```
+
+Run the database-backed import:
+
+```bash
+curl -X POST http://localhost:5258/api/import/run
+```
+
+Then view persisted data:
+
+```text
+GET /api/products
+GET /api/inventory
+GET /api/kpis
+```
+
+LLM features are not included in the current scope.
 
 ## Reports
 

--- a/src/Inventory.Api/Endpoints/ImportEndpoints.cs
+++ b/src/Inventory.Api/Endpoints/ImportEndpoints.cs
@@ -1,5 +1,7 @@
 using Inventory.Api.Extensions;
 using Inventory.Application.Interfaces;
+using Inventory.Domain.Entities;
+using Inventory.Domain.Enums;
 using Inventory.Infrastructure.FileParsing;
 
 namespace Inventory.Api.Endpoints;
@@ -11,8 +13,13 @@ internal static class ImportEndpoints
         app.MapPost("/api/import/run", async (
             ApiDataPaths paths,
             FileProcessor processor,
+            IProductFileReader productFileReader,
+            IInvoiceFileReader invoiceFileReader,
             IInventoryService inventoryService,
             IInventorySnapshotStore snapshotStore,
+            IProductRepository productRepository,
+            IInvoiceRepository invoiceRepository,
+            IInventoryRepository inventoryRepository,
             CancellationToken cancellationToken) =>
         {
             if (!Directory.Exists(paths.ProductsFolder) || !Directory.Exists(paths.InvoicesFolder))
@@ -33,24 +40,41 @@ internal static class ImportEndpoints
                 .OrderBy(file => file)
                 .ToList();
 
+            var products = new List<Product>();
+            var invoices = new List<Invoice>();
+
             foreach (var file in productFiles)
             {
+                products.AddRange(await productFileReader.ReadAsync(file, cancellationToken));
                 await processor.ProcessProductFileAsync(file, cancellationToken);
             }
 
             foreach (var file in invoiceFiles)
             {
+                invoices.AddRange(await invoiceFileReader.ReadAsync(file, cancellationToken));
                 await processor.ProcessInvoiceFileAsync(file, cancellationToken);
             }
 
+            var stockMovements = CreateStockMovements(invoices);
+
             snapshotStore.Save(inventoryService.Items);
+            await productRepository.ReplaceAsync(products, cancellationToken);
+            await invoiceRepository.ReplaceAsync(invoices, cancellationToken);
+            await inventoryRepository.ReplaceAsync(
+                inventoryService.GetAllInventory(),
+                stockMovements,
+                cancellationToken);
 
             return Results.Ok(new
             {
                 message = "Import completed.",
                 productFilesProcessed = productFiles.Count,
                 invoiceFilesProcessed = invoiceFiles.Count,
-                inventoryItems = inventoryService.Items.Count
+                productsPersisted = products.Count,
+                invoicesPersisted = invoices.Count,
+                stockMovementsPersisted = stockMovements.Count,
+                inventoryItems = inventoryService.Items.Count,
+                persistedToDatabase = true
             });
         })
         .WithName("RunImport")
@@ -60,5 +84,47 @@ internal static class ImportEndpoints
         .Produces(StatusCodes.Status404NotFound);
 
         return app;
+    }
+
+    private static List<StockMovement> CreateStockMovements(IEnumerable<Invoice> invoices)
+    {
+        return invoices
+            .SelectMany(invoice => invoice.LineItems
+                .Where(line => !string.IsNullOrWhiteSpace(line.ItemCode))
+                .Select(line => CreateStockMovement(invoice, line)))
+            .Where(movement => movement is not null)
+            .Select(movement => movement!)
+            .ToList();
+    }
+
+    private static StockMovement? CreateStockMovement(Invoice invoice, InvoiceLine line)
+    {
+        var quantity = (int)line.Quantity;
+
+        if (invoice.Type == InvoiceType.AccountsPayable)
+        {
+            return new StockMovement
+            {
+                ItemCode = line.ItemCode,
+                Type = StockMovementType.Purchase,
+                Quantity = quantity,
+                UnitCost = line.UnitAmount,
+                MovementDate = invoice.Date
+            };
+        }
+
+        if (invoice.Type == InvoiceType.AccountsReceivable)
+        {
+            return new StockMovement
+            {
+                ItemCode = line.ItemCode,
+                Type = StockMovementType.Sale,
+                Quantity = quantity,
+                UnitCost = line.UnitAmount,
+                MovementDate = invoice.Date
+            };
+        }
+
+        return null;
     }
 }

--- a/src/Inventory.Api/Endpoints/InventoryEndpoints.cs
+++ b/src/Inventory.Api/Endpoints/InventoryEndpoints.cs
@@ -6,8 +6,17 @@ internal static class InventoryEndpoints
 {
     public static IEndpointRouteBuilder MapInventoryEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/inventory", (IInventoryService inventoryService) =>
+        app.MapGet("/api/inventory", async (
+            IInventoryRepository inventoryRepository,
+            IInventoryService inventoryService,
+            CancellationToken cancellationToken) =>
         {
+            var databaseInventory = await TryGetDatabaseInventory(inventoryRepository, cancellationToken);
+            if (databaseInventory.Count > 0)
+            {
+                return Results.Ok(databaseInventory);
+            }
+
             var inventory = inventoryService.GetAllInventory()
                 .OrderBy(item => item.ItemCode)
                 .Select(item => new
@@ -37,5 +46,40 @@ internal static class InventoryEndpoints
         .Produces(StatusCodes.Status200OK);
 
         return app;
+    }
+
+    private static async Task<IReadOnlyList<object>> TryGetDatabaseInventory(
+        IInventoryRepository inventoryRepository,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var inventory = await inventoryRepository.GetAllAsync(cancellationToken);
+            return inventory
+                .Select(item => new
+                {
+                    item.ProductId,
+                    item.ItemCode,
+                    item.Name,
+                    item.QuantityOnHand,
+                    item.TotalSoldQuantity,
+                    item.TotalStockValue,
+                    PurchaseBatches = item.PurchaseBatches
+                        .OrderBy(batch => batch.PurchaseDate)
+                        .Select(batch => new
+                        {
+                            batch.PurchaseDate,
+                            batch.UnitCost,
+                            batch.InitialQuantity,
+                            batch.RemainingQuantity
+                        })
+                })
+                .Cast<object>()
+                .ToList();
+        }
+        catch
+        {
+            return Array.Empty<object>();
+        }
     }
 }

--- a/src/Inventory.Api/Endpoints/KpiEndpoints.cs
+++ b/src/Inventory.Api/Endpoints/KpiEndpoints.cs
@@ -1,5 +1,6 @@
 using Inventory.Application.DTOs;
 using Inventory.Application.Interfaces;
+using Inventory.Domain.Entities;
 
 namespace Inventory.Api.Endpoints;
 
@@ -7,9 +8,18 @@ internal static class KpiEndpoints
 {
     public static IEndpointRouteBuilder MapKpiEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/kpis", (IInventoryService inventoryService, IKpiService kpiService) =>
+        app.MapGet("/api/kpis", async (
+            IInventoryRepository inventoryRepository,
+            IInventoryService inventoryService,
+            IKpiService kpiService,
+            CancellationToken cancellationToken) =>
         {
-            var snapshot = kpiService.CreateSnapshot(inventoryService.GetAllInventory());
+            var inventory = await TryGetDatabaseInventory(inventoryRepository, cancellationToken);
+            var snapshot = kpiService.CreateSnapshot(
+                inventory.Count > 0
+                    ? inventory.ToList()
+                    : inventoryService.GetAllInventory());
+
             return Results.Ok(snapshot);
         })
         .WithName("GetKpis")
@@ -18,5 +28,19 @@ internal static class KpiEndpoints
         .Produces<KpiResult>(StatusCodes.Status200OK);
 
         return app;
+    }
+
+    private static async Task<IReadOnlyList<InventoryItem>> TryGetDatabaseInventory(
+        IInventoryRepository inventoryRepository,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await inventoryRepository.GetAllAsync(cancellationToken);
+        }
+        catch
+        {
+            return Array.Empty<InventoryItem>();
+        }
     }
 }

--- a/src/Inventory.Api/Endpoints/ProductEndpoints.cs
+++ b/src/Inventory.Api/Endpoints/ProductEndpoints.cs
@@ -6,8 +6,17 @@ internal static class ProductEndpoints
 {
     public static IEndpointRouteBuilder MapProductEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/products", (IInventoryService inventoryService) =>
+        app.MapGet("/api/products", async (
+            IProductRepository productRepository,
+            IInventoryService inventoryService,
+            CancellationToken cancellationToken) =>
         {
+            var databaseProducts = await TryGetDatabaseProducts(productRepository, cancellationToken);
+            if (databaseProducts.Count > 0)
+            {
+                return Results.Ok(databaseProducts);
+            }
+
             var products = inventoryService.GetAllInventory()
                 .OrderBy(item => item.ItemCode)
                 .Select(item => new
@@ -25,5 +34,28 @@ internal static class ProductEndpoints
         .Produces(StatusCodes.Status200OK);
 
         return app;
+    }
+
+    private static async Task<IReadOnlyList<object>> TryGetDatabaseProducts(
+        IProductRepository productRepository,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var products = await productRepository.GetAllAsync(cancellationToken);
+            return products
+                .Select(product => new
+                {
+                    product.ProductId,
+                    product.ItemCode,
+                    product.Name
+                })
+                .Cast<object>()
+                .ToList();
+        }
+        catch
+        {
+            return Array.Empty<object>();
+        }
     }
 }

--- a/src/Inventory.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Inventory.Api/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Inventory.Application.Services;
 using Inventory.Infrastructure.FileParsing;
 using Inventory.Infrastructure.Json;
 using Inventory.Infrastructure.Persistence;
+using Inventory.Infrastructure.Persistence.Repositories;
 using Inventory.Infrastructure.Reporting;
 using Microsoft.EntityFrameworkCore;
 
@@ -54,6 +55,9 @@ internal static class ServiceCollectionExtensions
         });
         services.AddSingleton<IProductFileReader, ProductFileReader>();
         services.AddSingleton<IInvoiceFileReader, InvoiceFileReader>();
+        services.AddScoped<IProductRepository, ProductRepository>();
+        services.AddScoped<IInvoiceRepository, InvoiceRepository>();
+        services.AddScoped<IInventoryRepository, InventoryRepository>();
         services.AddSingleton<IProcessedFileRegistry>(_ =>
             new ProcessedFileRegistry(Path.Combine(dataPaths.RuntimeRoot, "processed-files")));
         services.AddSingleton<IReportWriter>(_ =>

--- a/src/Inventory.Application/Interfaces/IInventoryRepository.cs
+++ b/src/Inventory.Application/Interfaces/IInventoryRepository.cs
@@ -1,0 +1,13 @@
+using Inventory.Domain.Entities;
+
+namespace Inventory.Application.Interfaces;
+
+public interface IInventoryRepository
+{
+    Task<IReadOnlyList<InventoryItem>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task ReplaceAsync(
+        IEnumerable<InventoryItem> inventoryItems,
+        IEnumerable<StockMovement> stockMovements,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Inventory.Application/Interfaces/IInvoiceRepository.cs
+++ b/src/Inventory.Application/Interfaces/IInvoiceRepository.cs
@@ -1,0 +1,10 @@
+using Inventory.Domain.Entities;
+
+namespace Inventory.Application.Interfaces;
+
+public interface IInvoiceRepository
+{
+    Task<IReadOnlyList<Invoice>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task ReplaceAsync(IEnumerable<Invoice> invoices, CancellationToken cancellationToken = default);
+}

--- a/src/Inventory.Application/Interfaces/IProductRepository.cs
+++ b/src/Inventory.Application/Interfaces/IProductRepository.cs
@@ -1,0 +1,10 @@
+using Inventory.Domain.Entities;
+
+namespace Inventory.Application.Interfaces;
+
+public interface IProductRepository
+{
+    Task<IReadOnlyList<Product>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task ReplaceAsync(IEnumerable<Product> products, CancellationToken cancellationToken = default);
+}

--- a/src/Inventory.Infrastructure/Persistence/Repositories/InventoryRepository.cs
+++ b/src/Inventory.Infrastructure/Persistence/Repositories/InventoryRepository.cs
@@ -1,0 +1,113 @@
+using Inventory.Application.Interfaces;
+using Inventory.Domain.Entities;
+using Inventory.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace Inventory.Infrastructure.Persistence.Repositories;
+
+public class InventoryRepository : IInventoryRepository
+{
+    private readonly InventoryDbContext _dbContext;
+
+    public InventoryRepository(InventoryDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<InventoryItem>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var items = await _dbContext.InventoryItems
+            .AsNoTracking()
+            .Include(item => item.PurchaseBatches)
+            .OrderBy(item => item.ItemCode)
+            .ToListAsync(cancellationToken);
+
+        var saleMovements = await _dbContext.StockMovements
+            .AsNoTracking()
+            .Where(movement => movement.Type == StockMovementType.Sale)
+            .OrderBy(movement => movement.MovementDate)
+            .ToListAsync(cancellationToken);
+
+        var saleDateLookup = saleMovements
+            .GroupBy(movement => movement.ItemCode)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(movement => movement.MovementDate).ToList());
+
+        foreach (var item in items)
+        {
+            if (saleDateLookup.TryGetValue(item.ItemCode, out var dates))
+            {
+                item.SaleDates = dates;
+            }
+        }
+
+        return items;
+    }
+
+    public async Task ReplaceAsync(
+        IEnumerable<InventoryItem> inventoryItems,
+        IEnumerable<StockMovement> stockMovements,
+        CancellationToken cancellationToken = default)
+    {
+        await _dbContext.StockLots.ExecuteDeleteAsync(cancellationToken);
+        await _dbContext.StockMovements.ExecuteDeleteAsync(cancellationToken);
+        await _dbContext.InventoryItems.ExecuteDeleteAsync(cancellationToken);
+
+        var items = inventoryItems
+            .Where(item => !string.IsNullOrWhiteSpace(item.ItemCode))
+            .GroupBy(item => item.ItemCode)
+            .Select(group => NormalizeInventoryItem(group.Last()))
+            .ToList();
+
+        var movements = stockMovements
+            .Where(movement => !string.IsNullOrWhiteSpace(movement.ItemCode))
+            .Select(NormalizeStockMovement)
+            .ToList();
+
+        await _dbContext.InventoryItems.AddRangeAsync(items, cancellationToken);
+        await _dbContext.StockMovements.AddRangeAsync(movements, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static InventoryItem NormalizeInventoryItem(InventoryItem item)
+    {
+        return new InventoryItem
+        {
+            ProductId = string.IsNullOrWhiteSpace(item.ProductId)
+                ? item.ItemCode
+                : item.ProductId,
+            ItemCode = item.ItemCode,
+            Name = item.Name,
+            TotalSoldQuantity = item.TotalSoldQuantity,
+            PurchaseBatches = item.PurchaseBatches
+                .Select(lot => new StockLot
+                {
+                    PurchaseDate = AsUtc(lot.PurchaseDate),
+                    UnitCost = lot.UnitCost,
+                    InitialQuantity = lot.InitialQuantity,
+                    RemainingQuantity = lot.RemainingQuantity
+                })
+                .ToList()
+        };
+    }
+
+    private static StockMovement NormalizeStockMovement(StockMovement movement)
+    {
+        return new StockMovement
+        {
+            ItemCode = movement.ItemCode,
+            Type = movement.Type,
+            Quantity = movement.Quantity,
+            UnitCost = movement.UnitCost,
+            MovementDate = AsUtc(movement.MovementDate)
+        };
+    }
+
+    private static DateTime AsUtc(DateTime value)
+    {
+        return value.Kind == DateTimeKind.Utc
+            ? value
+            : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+    }
+}

--- a/src/Inventory.Infrastructure/Persistence/Repositories/InvoiceRepository.cs
+++ b/src/Inventory.Infrastructure/Persistence/Repositories/InvoiceRepository.cs
@@ -1,0 +1,67 @@
+using Inventory.Application.Interfaces;
+using Inventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Inventory.Infrastructure.Persistence.Repositories;
+
+public class InvoiceRepository : IInvoiceRepository
+{
+    private readonly InventoryDbContext _dbContext;
+
+    public InvoiceRepository(InventoryDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<Invoice>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Invoices
+            .AsNoTracking()
+            .Include(invoice => invoice.LineItems)
+            .OrderBy(invoice => invoice.Date)
+            .ThenBy(invoice => invoice.InvoiceNumber)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task ReplaceAsync(IEnumerable<Invoice> invoices, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.InvoiceLines.ExecuteDeleteAsync(cancellationToken);
+        await _dbContext.Invoices.ExecuteDeleteAsync(cancellationToken);
+
+        var uniqueInvoices = invoices
+            .Where(invoice => !string.IsNullOrWhiteSpace(invoice.InvoiceID))
+            .GroupBy(invoice => invoice.InvoiceID)
+            .Select(group => NormalizeInvoice(group.Last()))
+            .ToList();
+
+        await _dbContext.Invoices.AddRangeAsync(uniqueInvoices, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static Invoice NormalizeInvoice(Invoice invoice)
+    {
+        return new Invoice
+        {
+            InvoiceID = invoice.InvoiceID,
+            InvoiceNumber = invoice.InvoiceNumber,
+            Type = invoice.Type,
+            Date = AsUtc(invoice.Date),
+            LineItems = invoice.LineItems
+                .Where(line => !string.IsNullOrWhiteSpace(line.ItemCode))
+                .Select(line => new InvoiceLine
+                {
+                    ItemCode = line.ItemCode,
+                    Quantity = line.Quantity,
+                    UnitAmount = line.UnitAmount
+                })
+                .ToList()
+        };
+    }
+
+    private static DateTime AsUtc(DateTime value)
+    {
+        return value.Kind == DateTimeKind.Utc
+            ? value
+            : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+    }
+}

--- a/src/Inventory.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/src/Inventory.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -1,0 +1,49 @@
+using Inventory.Application.Interfaces;
+using Inventory.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Inventory.Infrastructure.Persistence.Repositories;
+
+public class ProductRepository : IProductRepository
+{
+    private readonly InventoryDbContext _dbContext;
+
+    public ProductRepository(InventoryDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<Product>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Products
+            .AsNoTracking()
+            .OrderBy(product => product.ItemCode)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task ReplaceAsync(IEnumerable<Product> products, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.Products.ExecuteDeleteAsync(cancellationToken);
+
+        var uniqueProducts = products
+            .Where(product => !string.IsNullOrWhiteSpace(product.ItemCode))
+            .GroupBy(product => product.ItemCode)
+            .Select(group => NormalizeProduct(group.Last()))
+            .ToList();
+
+        await _dbContext.Products.AddRangeAsync(uniqueProducts, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static Product NormalizeProduct(Product product)
+    {
+        return new Product
+        {
+            ProductId = string.IsNullOrWhiteSpace(product.ProductId)
+                ? product.ItemCode
+                : product.ProductId,
+            ItemCode = product.ItemCode,
+            Name = product.Name
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Added repository abstractions and EF Core repository implementations
- Persisted imported products, invoices, inventory items, stock lots, and stock movements to PostgreSQL
- Updated API endpoints to read inventory data from the database
- Kept existing FIFO and KPI business logic unchanged
- Updated README with database-backed import workflow

## Validation
- dotnet build InventoryKpiSystem.sln
- dotnet test InventoryKpiSystem.sln

## Notes
- File-based import remains the source of input data
- PostgreSQL is now used for persisted inventory state
- No frontend, authentication, message queue, Docker, or LLM features were added